### PR TITLE
maintain telnet connection across ime switches

### DIFF
--- a/src/de/onyxbits/remotekeyboard/RemoteKeyboardService.java
+++ b/src/de/onyxbits/remotekeyboard/RemoteKeyboardService.java
@@ -61,6 +61,12 @@ public class RemoteKeyboardService extends InputMethodService implements
 	protected HashMap<String, String> replacements;
 
 	/**
+	 * Input to GUI
+	 */
+	protected static TextInputAction tia;
+	protected static CtrlInputAction cia;
+
+	/**
 	 * Reference to the telnetserver instance
 	 */
 	private TelnetD telnetServer;
@@ -84,6 +90,9 @@ public class RemoteKeyboardService extends InputMethodService implements
 			if (telnetServer == null) {
 				telnetServer = TelnetD.createTelnetD(props);
 			}
+			tia = new TextInputAction(self);
+			cia = new CtrlInputAction(self);
+
 			telnetServer.start();
 
 			updateNotification(null);
@@ -120,9 +129,6 @@ public class RemoteKeyboardService extends InputMethodService implements
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
-		if (telnetServer != null) {
-			telnetServer.stop();
-		}
 		NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 		notificationManager.cancel(NOTIFICATION);
 		self = null;


### PR DESCRIPTION
My implementation mainly involves not destroying the telnet server on remote keyboard destroy, and a couple changes that necessarily follow from this.

An alternative approach might be to return from server input loop, but maintain socket connection in connection accept loop, blocking there on a semaphore signaled when ime is returned to remote keyboard, and then restarting the input loop.  This however might make for an unnecessarily busier input loop (input loop polling for whether it should exit), as the present implementation already has the input loop blocking on io read.

Comments, observations, suggestions, advice appreciated.